### PR TITLE
Update all files to reference Redot and use Redot links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,9 +3,9 @@ blank_issues_enabled: false
 
 contact_links:
   - name: Share and discuss ideas
-    url: https://github.com/godotengine/godot-proposals/discussions
-    about: Discuss any idea related to improving Godot
+    url: https://github.com/redot-engine/redot-proposals/discussions
+    about: Discuss any idea related to improving Redot
 
-  - name: Main Godot repository
-    url: https://github.com/godotengine/godot
+  - name: Main Redot repository
+    url: https://github.com/redot-engine/redot-engine
     about: Report bugs on the main Godot repository

--- a/.github/ISSUE_TEMPLATE/feature_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/feature_proposal.yml
@@ -6,7 +6,7 @@ body:
   attributes:
     value: |
       - Write a descriptive proposal title above.
-      - Search [open](https://github.com/godotengine/godot-proposals/issues) and [closed](https://github.com/godotengine/godot-proposals/issues?q=is%3Aissue+is%3Aclosed) proposals to ensure the feature has not already been suggested.
+      - Search [open](https://github.com/Redot-Engine/redot-proposals/issues) and [closed](https://github.com/Redot-Engine/redot-proposals/issues?q=is%3Aissue+is%3Aclosed) proposals to ensure the feature has not already been suggested.
 
 - type: textarea
   attributes:

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,5 @@
 Copyright (c) 2019-present Godot Engine contributors.
+Copyright (c) 2024-present Redot Engine contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,39 +1,38 @@
-# Godot Improvement Proposals
+# Redot Improvement Proposals
 
 This repository serves as the central hub for proposing, discussing, and
-reviewing new features and enhancements in Godot Engine. While there exists
+reviewing new features and enhancements in Redot Engine. While there exists
 some leeway, most changes made to the engine must go through the proposal
 process first. The goal is to determine whether the suggestion makes sense
-for the majority of Godot users, and to figure out the best approach to
+for the majority of Redot users, and to figure out the best approach to
 implement it.
 
 As such, everyone is welcome to participate in ongoing discussions, or start
 a new one.
 
-> **Tip:** Use the [Godot proposals viewer](https://godot-proposals-viewer.github.io/)
-> to view all open proposals on a single page. This allows for easy searching
-> in proposal titles using <kbd>Ctrl + F</kbd> or <kbd>Cmd + F</kbd>.
+> **Tip:** Use the [Redot proposals viewer](http://proposals.redotengine.org/)
+> to view all open proposals on a single page.
 
 Bug reports are not a subject of the proposal process. If you experience
-an issue while using Godot that cannot be attributed to a missing feature,
-please open a report in the [main Godot repository](https://github.com/godotengine/godot).
+an issue while using Redot that cannot be attributed to a missing feature,
+please open a report in the [main Redot repository](https://github.com/Redot-Engine/redot-engine).
 Feel free to open a pull-request based on any bug report as well!
 
 ## Suggesting improvements
 
 You have two options to make a suggestion for the future of the engine. You
-can either open a proposal [**Issue**](https://github.com/godotengine/godot-proposals/issues/new/choose),
-or you can create an open [**Discussion**](https://github.com/godotengine/godot-proposals/discussions/new).
+can either open a proposal [**Issue**](https://github.com/Redot-Engine/redot-proposals/issues/new/choose),
+or you can create an open [**Discussion**](https://github.com/Redot-Engine/redot-proposals/discussions/new).
 
 Proposal *issues* are required to explain in technical detail how the suggested change
 should be implemented. It is also preferred that the submitter of a proposal is
 ready to implement it if it was approved. If you have a more general idea for
-a feature but are not well versed in Godot's architecture or do not possess
+a feature but are not well versed in Redot's architecture or do not possess
 the necessary knowledge to implement it in the engine, feel free to open a
-[*discussion*](https://github.com/godotengine/godot-proposals/discussions/new)
-instead of an [*issue*](https://github.com/godotengine/godot-proposals/issues/new/choose).
+[*discussion*](https://github.com/Redot-Engine/redot-proposals/discussions/new)
+instead of an [*issue*](https://github.com/Redot-Engine/redot-proposals/issues/new/choose).
 
-A valid feature proposal will be held open to allow fellow Godot users and
+A valid feature proposal will be held open to allow fellow Redot users and
 contributors to weigh in on the suggestion and its implementation. While all
 opinions are considered, a core developer must approve the feature and its
 implementation for a proposal to be considered ready to implement.
@@ -44,7 +43,7 @@ Don't fork this repository to open a proposal.
 ## Rules for submitting a proposal
 
 > **Note:** The following points describe requirements for a proposal issue. A
-> [discussion](https://github.com/godotengine/godot-proposals/discussions/new),
+> [discussion](https://github.com/Redot-Engine/redot-proposals/discussions/new),
 > on the other hand, can be started in any form.
 
 1. Only proposals that properly fill out the template will be considered. If
@@ -56,21 +55,13 @@ individually.
 
 3. All proposals must be linked to a substantive use-case. In justifying your
 proposal, it is not enough to say it would be "nice" or "helpful". Use the
-template to show how Godot is not currently meeting your needs and then
+template to show how Redot is not currently meeting your needs and then
 explain how your proposal will meet a particular need.
 
-   * If you feel that you cannot provide highly detailed instructions with the
-     proposal, consider creating a more simple, open-ended issue in the
-     unofficial, community-maintained
-     [Godot Ideas](https://github.com/godot-extended-libraries/godot-ideas)
-     repository.
-
 4. Other users must express interest in your proposal for it to be considered.
-Godot is community-driven: if no other users are interested in your proposal,
+Redot is community-driven: if no other users are interested in your proposal,
 it may be closed. It is up to you to draw interest in your proposed feature.
-Start by reaching out on the community channels (Reddit, Discord,
-[Godot Contributors Chat](https://chat.godotengine.org/)), etc.
-see the [Community Channels](http://docs.godotengine.org/en/stable/community/channels.html) doc),
+Start by reaching out on the community [Discord Server](https://discord.gg/redot),
 then create your proposal once you have gained some interest.
 
 5. You can make a PR implementing the feature in the main repository before
@@ -95,12 +86,12 @@ with your own idea. You don't need to copy-paste your whole proposal's text. Ins
 rephrase the main ideas and add mockups if needed.
 
 If your proposal was closed because of lack of interest, then try to build up
-some interest on the [community channels](http://docs.godotengine.org/en/stable/community/channels.html)
+some interest on the [Discord Server](https://discord.gg/redot)
 and then ask the person who closed the issue to re-open it.
 
 If your proposal was closed because a core contributor determined that it was
 not worth pursuing and you feel that it was wrongly closed, then feel free
-to join the [Godot Contributors Chat](https://chat.godotengine.org/)
+to join the [Discord Server](https://discord.gg/redot)
 and have a more in-depth discussion with other core developers about the feature.
 
 ## How core developers evaluate proposals
@@ -163,6 +154,3 @@ to be accepted.
 
 The above considerations are all balanced, no one is more important than another.
 Core developers have discretion to weigh the factors as they see fit.
-
-In addition to the above guideline, consider [this article](https://docs.godotengine.org/en/latest/community/contributing/best_practices_for_engine_contributors.html)
-which outlines what core developers consider when evaluating PRs.

--- a/TRIAGE-AND-REVIEW.md
+++ b/TRIAGE-AND-REVIEW.md
@@ -1,4 +1,4 @@
-## Triaging Godot proposals
+## Triaging Redot proposals
 
 When a new proposal is added, it needs to be triaged. Existing proposals sometimes require
 re-triaging as well. The main goal of triaging a proposal is:
@@ -19,18 +19,18 @@ with an existing discussion.
 To help track proposals, plan future work, and organize review meetings, we use a dedicated
 GitHub project:
 
-https://github.com/orgs/godotengine/projects/37
+https://github.com/orgs/Redot-Engine/projects/9
 
 Triagers need to add the new proposal to this project, set its "**Status**" to "_In Discussion_" and
 its "**Feature Concept**" and "**Proposed Implementation**" fields to "_Unassessed_".
 
-## Reviewing Godot proposals
+## Reviewing Redot proposals
 
 Each proposal review starts with a public discussion. Stakeholders, area maintainers, as well as
 users of the engine can participate in the discourse, support or raise concern and try to
 forge the initial draft of a feature into a shape that solves the problem for the majority of users.
 
-> See Godot documentation to learn about [the engine design philosophy](https://docs.godotengine.org/en/stable/community/contributing/best_practices_for_engine_contributors.html).
+> See Redot documentation to learn about [the engine design philosophy](https://docs.redotengine.org/en/stable/community/contributing/best_practices_for_engine_contributors.html).
 
 For some areas of the engine, area maintainers can decide on the feature during this period of public
 discussion. In a lot of cases, though, the proposal can be put for review during a proposal review
@@ -70,7 +70,7 @@ status is all encompassing. The details can be explained in the closing message 
 as well as expressed with appropriate "**Feature Concept**" and "**Proposed Implementation**" status.
 
 A proposal can be put "_On Hold_" if it depends on another feature to be implemented first, it
-requires more time from the author, or if the decision was postponed until a future version of Godot.
+requires more time from the author, or if the decision was postponed until a future version of Redot.
 
 "_Implemented_" is self-explanatory. Note, that a proposal may still be open even if it marked as implemented.
 In such a case this indicates that while the feature has not been merged yet, it is complete
@@ -78,10 +78,10 @@ and new PRs are not required.
 
 ### Feature Concept
 
-The "**Feature Concept**" field is used to indicate if the proposed solution, conceptually, fits Godot.
+The "**Feature Concept**" field is used to indicate if the proposed solution, conceptually, fits Redot.
 This is different from approving the implementation. When the feature is approved it means that
 the problem described by the proposal is considered valid and that it is worth solving. It also means
-that the solution must be provided by the Godot engine team. This can mean a core change, or
+that the solution must be provided by the Redot engine team. This can mean a core change, or
 an _official_ extension.
 
 "**Feature Concept**" can have following values:
@@ -156,7 +156,7 @@ doesn't have complete support or has strong opposition.
 
 The GitHub project used to track proposals is here:
 
-https://github.com/orgs/godotengine/projects/37
+https://github.com/orgs/Redot-Engine/projects/9
 
 It has several board views that allow to quickly find the issues that need to be discussed or can be
 implemented. It also gives a complete look for slices based on "**Status**", "**Feature Concept**",
@@ -164,7 +164,7 @@ and "**Proposed Implementation**". Any organization member can add issues to be 
 so please use it responsibly and don't forget to assign correct values if you do so.
 
 You can add an issue to the project from the issue's page directly. Use the gear icon in the sidebar
-next to the "**Projects**" title and select "_Godot Proposal Metaverse_" from the list of available projects.
+next to the "**Projects**" title and select "_Redot Proposal Feed_" from the list of available projects.
 Status is automatically set to the default value, "_In Discussion_", even though it doesn't update visibly.
 You can still set it, or set it to another appropriate value.
 
@@ -174,8 +174,8 @@ You can still set it, or set it to another appropriate value.
 
 You can find all the issues in the project using this search filter:
 
-https://github.com/godotengine/godot-proposals/issues?q=is%3Aopen+is%3Aissue+project%3Agodotengine%2F37
+https://github.com/redot-engine/redot-proposals/issues?q=is%3Aopen+is%3Aissue+project%3Aredot-engine%2F9
 
 You can find all the issues **not** in the project yet using this search filter:
 
-https://github.com/godotengine/godot-proposals/issues?q=is%3Aopen+is%3Aissue+-project%3Agodotengine%2F37
+https://github.com/redot-engine/redot-proposals/issues?q=is%3Aopen+is%3Aissue+-project%3Aredot-engine%2F9


### PR DESCRIPTION
Replaced all instances of the name Godot with Redot
Updated all links to point to their respective Redot counterparts
Added Redot to copyright notice

supersedes #2
supersedes #1

Changes suggested by both [stellarorion](https://github.com/stellarorion) and [PuzzleOxide](https://github.com/PuzzleOxide) have been implemented in this combined pr.